### PR TITLE
Prevents adding an extra div

### DIFF
--- a/src/Toast.fs
+++ b/src/Toast.fs
@@ -436,7 +436,7 @@ module Toast =
                             subscribe model.UserModel |> Cmd.map UserMsg ]
 
             let mapView view' model dispatch =
-                div [ ]
+                fragment [ ]
                     [ view renderer model dispatch
                       view' model.UserModel (UserMsg >> dispatch) ]
 


### PR DESCRIPTION
Using [React Fragment](https://reactjs.org/docs/fragments.html) avoids the need of an empty div to insert the elmish-toast.

![image](https://user-images.githubusercontent.com/8275461/57010845-28643880-6bff-11e9-8665-ca87751e509a.png)
