### PR TITLE
[WIP] Update CustomEventInit to handle generic type

### DIFF
--- a/demo/src/Demo.fsproj
+++ b/demo/src/Demo.fsproj
@@ -12,7 +12,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Fable.Browser.Dom" Version="2.3.0" />
-      <PackageReference Include="Fable.Core" Version="3.2.6" />
+      <PackageReference Include="Fable.Core" Version="3.2.7" />
       <PackageReference Include="Fable.Elmish" Version="3.1.0" />
       <PackageReference Include="Fable.Elmish.Browser" Version="3.0.4" />
       <PackageReference Include="Fable.Elmish.Hmr" Version="4.1.0" />

--- a/src/Thoth.Elmish.Toast.fsproj
+++ b/src/Thoth.Elmish.Toast.fsproj
@@ -19,9 +19,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="3.2.7" />
-    <PackageReference Include="Fable.Elmish" Version="3.1.0" />
-    <PackageReference Include="Fable.Promise" Version="2.2.0" />
-    <PackageReference Include="Fable.React" Version="7.4.0" />
+    <PackageReference Include="Fable.Elmish" Version="3.0.0" />
+    <PackageReference Include="Fable.Promise" Version="2.0.0" />
+    <PackageReference Include="Fable.React" Version="5.1.0" />
     <PackageReference Include="Fable.Browser.Event" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Thoth.Elmish.Toast.fsproj
+++ b/src/Thoth.Elmish.Toast.fsproj
@@ -18,10 +18,11 @@
     <Compile Include="Toast.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.0.0" />
-    <PackageReference Include="Fable.Elmish" Version="3.0.0" />
-    <PackageReference Include="Fable.Promise" Version="2.0.0" />
-    <PackageReference Include="Fable.React" Version="5.1.0" />
+    <PackageReference Include="Fable.Core" Version="3.2.7" />
+    <PackageReference Include="Fable.Elmish" Version="3.1.0" />
+    <PackageReference Include="Fable.Promise" Version="2.2.0" />
+    <PackageReference Include="Fable.React" Version="7.4.0" />
+    <PackageReference Include="Fable.Browser.Event" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; **\*.fs; **\*.css" PackagePath="fable" />

--- a/src/Toast.fs
+++ b/src/Toast.fs
@@ -168,11 +168,11 @@ module Toast =
             WithCloseButton = true
         }
 
-    let private triggerEvent (builder : Builder<'icon, 'msg>) status dispatch =
+    let private triggerEvent<'a> (builder : Builder<'icon, 'msg>) status dispatch =
         let detail =
-            jsOptions<CustomEventInit>(fun o ->
+            jsOptions<CustomEventInit<_>>(fun o ->
                 o.detail <-
-                    {
+                    Some {
                         Guid = Guid.NewGuid()
                         Message = builder.Message
                         Title = builder.Title
@@ -480,14 +480,14 @@ module Toast =
                         window.removeEventListener(EVENT_IDENTIFIER, !!window?(EVENT_IDENTIFIER))
 
                     window?(EVENT_IDENTIFIER) <- fun (ev : Event) ->
-                        let ev = ev :?> CustomEvent
+                        let ev = ev :?> CustomEvent<_>
                         dispatch (Add (unbox ev.detail))
 
                     window.addEventListener(EVENT_IDENTIFIER, !!window?(EVENT_IDENTIFIER))
                 else
                 #endif
                     window.addEventListener(EVENT_IDENTIFIER, fun ev ->
-                        let ev = ev :?> CustomEvent
+                        let ev = ev :?> CustomEvent<_>
                         dispatch (Add (unbox ev.detail))
                     )
 


### PR DESCRIPTION
This is a first pass at resolving #30. This passes along more generic information to prevent them from being constrained to object, and specifies the generic type for `CustomEventInit`. 

**However, there is currently a bug** where the generated JS is something like this:

```
new (CustomEvent())("thoth_elmish_toast_notify_event", detail$$3);
```

Which is invalid because `CustomEvent()` doesn't have a `new` keyword.

I'm not sure if this is because of my changes here, the code I tested with that's running this (I can't figure out how to get Demo to start), or - my actual guess - something upstream. I'm opening the MR to get some eyes on this, hopefully I've missed something simple that'll resolve this faster.